### PR TITLE
update docs and use central task configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ site
 
 .github/styles/*
 !.github/styles/config/
+.task

--- a/README.md
+++ b/README.md
@@ -9,10 +9,35 @@ This project is intended to help create GitHub structures that are as standardis
 The Generated Project has:
 
 * Pre-configured GitHub Actions and Settings based on [nolte/gh-plumbing](https://github.com/nolte/gh-plumbing).
-* Documentation with [mkdocs]()
+    * [Release Process](https://nolte.github.io/gh-plumbing/features/release/)
+    * [Publishing Documentation](https://nolte.github.io/gh-plumbing/features/mkdocs/)
+    * Minimal set of [static tests](https://nolte.github.io/gh-plumbing/features/static-tests/)
+    * Automatic [labelling](https://nolte.github.io/gh-plumbing/features/labelling/)
+* Documentation with [mkdocs](https://github.com/mkdocs/mkdocs)
 <!--intro-end-->
 
 ## Usage
+
+Using [cookiecutter/cookiecutter](https://github.com/cookiecutter/cookiecutter) directly for generate a new GitHub Project Structure.
+
+<!--usage-cmd-start-->
+```sh
+cookiecutter gh:nolte/cookiecutter-gh-project \
+    module_slug="cookiecutter-gh-project" \
+    topics="templating, cookiecutter, github" \
+    description="Template for Create GitHub Workflows and Projects" \
+    template_issues="y" \
+    template_pull_request="y" \
+    readme_enabled="y" \
+    docs_enabled="y" \
+    renovate_enabled="y" \
+    -f --no-input
+```
+<!--usage-cmd-end-->
+
+
+## Development
+
 
 ```bash
 cookiecutter ./cookiecutter-gh-project \
@@ -26,17 +51,10 @@ cookiecutter ./cookiecutter-gh-project \
     dependabot_pip="y" \
     dependabot_gitsubmodule="n" \
     dependabot_docker="n" \
-    -f --no-input
-
-cookiecutter gh:nolte/cookiecutter-gh-project \
-    module_slug="cookiecutter-gh-project" \
-    topics="templating, cookiecutter, github" \
-    description="Template for Create GitHub Workflows and Projects" \
-    template_issues="y" \
-    template_pull_request="y" \
-    dependabot_github_actions="y" \
-    dependabot_pip="y" \
-    dependabot_gitsubmodule="n" \
-    dependabot_docker="n" \
-    -f --no-input
+    -f --no-input --output-dir /tmp
 ```
+
+## Links
+
+* [nolte/taskfiles](https://github.com/nolte/taskfiles), as task collection.
+* [nolte/gh-plumbing](https://github.com/nolte/gh-plumbing), for central managed GitHub actions.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,10 +2,15 @@
 
 version: '3'
 
+vars:
+  TASK_COLLECTION_BASE: https://raw.githubusercontent.com/nolte/taskfiles/fix/py-var-names/src
+
+includes:
+  mkdocs: "{{.TASK_COLLECTION_BASE}}/taskfile-include-mkdocs.yaml"
+  pre-commit: "{{.TASK_COLLECTION_BASE}}/taskfile-include-pre-commit.yaml"
 
 tasks:
-  generate-project:
-    desc: Start Precommit
+  default:
     cmds:
-      - pre-commit run -a
+    - task -l
     silent: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,38 +1,19 @@
 # Template
 
-This Template Project use [CookieCutter](https://github.com/cookiecutter/cookiecutter) for generate/boostrap GitHub Projects. With a base set of CI/CD tools and Release Process.
-
-## Scope from the Templates
-
-This Template should be handle different base Ci/Cd steps.
-
-### Static Tests
-
-Generate a base set of workflows for execute Static Tests, like linting.
-
-* [pre-commit/action](https://github.com/pre-commit/action)
-* [zbeekman/EditorConfig-Action](https://github.com/zbeekman/EditorConfig-Action)
-
-### Release Process
-
-The Release Process will be implemented by different Workflows and Apps, for example [toolmantim/release-drafter](https://github.com/toolmantim/release-drafter) for creating a GitHub Changelog.
-
-#### Release Publish Docs
-
-* [mhausenblas/mkdocs-deploy-gh-pages](https://github.com/mhausenblas/mkdocs-deploy-gh-pages)
-
-### Project Configuration
-
-#### Settings
-
-* [probot/settings](https://github.com/probot/settings)
+{%
+   include-markdown "../README.md"
+   start="<!--intro-start-->"
+   end="<!--intro-end-->"
+%}
 
 
-#### Labeling
+## Scope and out-off from the Templates
 
-* [probot/stale](https://github.com/probot/stale)
-* [kaxil/boring-cyborg](https://github.com/kaxil/boring-cyborg)
+**In Scope**, of this Template should be handle different base Ci/Cd steps and boilerplate code for working with sources.
 
-#### Templates
+**Out of scope**, are the `source-code` implementation.
+
+
+## Templates
 
 * [docs.github.com Templates](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,49 @@
+# Usage
+
+
+## Create Project
+
+command for **generate** new Project,
+
+{%
+   include-markdown "../README.md"
+   start="<!--usage-cmd-start-->"
+   end="<!--usage-cmd-end-->"
+%}
+
+
+### Generated structure
+
+```sh
+.
+├── docs
+│   ├── css
+│   │   └── overwrite.css
+│   └── index.md
+├── .github
+│   ├── boring-cyborg.yml
+│   ├── ISSUE_TEMPLATE
+│   │   ├── bug_report.md
+│   │   ├── config.yml
+│   │   └── feature_request.md
+│   ├── pull_request_template.md
+│   ├── release-drafter.yml
+│   ├── settings.yml
+│   ├── stale.yml
+│   └── workflows
+│       ├── automerge.yaml
+│       ├── build-static-tests.yaml
+│       ├── release-cd-deliver-docs.yml
+│       ├── release-cd-refresh-master.yml
+│       ├── release-drafter.yml
+│       └── spelling.yaml
+├── .gitignore
+├── mkdocs.yml
+├── .pre-commit-config.yaml
+├── README.md
+├── renovate.json5
+├── requirements-dev.txt
+└── .vale.ini
+
+5 directories, 23 files
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,15 @@
 site_name: Github Cookiecutter Templates
-theme: material
+theme:
+  name: material
+docs_dir: docs/
+repo_name: 'nolte/cookiecutter-gh-project'
+repo_url: 'https://github.com/nolte/cookiecutter-gh-project'
+plugins:
+  - include-markdown
 markdown_extensions:
+  - pymdownx.inlinehilite:
+  - pymdownx.superfences:
+  - pymdownx.highlight:
   - toc:
       permalink: True
 extra_css:

--- a/{{cookiecutter.module_slug}}/.gitignore
+++ b/{{cookiecutter.module_slug}}/.gitignore
@@ -2,3 +2,4 @@ site
 
 .github/styles/*
 !.github/styles/config/
+.task


### PR DESCRIPTION
### Description

Split Docs and add refs to central management project [nolte/gh-plumbing](https://github.com/nolte/gh-plumbing)

### Acceptance tests
- [x] Have you added an acceptance test for the functionality?
- [x] Have you run the acceptance tests on this branch?

### Documentation
- [x] Have you create or updated the documentation at ``./docs``?

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers rank this request
* If you interested in working on this issue or have submitted a pull request, please leave a comment
