### PR TITLE
chore(template): add release-publish.yml to satisfy branching-model spec

### DIFF
--- a/{{cookiecutter.module_slug}}/.github/workflows/release-publish.yml
+++ b/{{cookiecutter.module_slug}}/.github/workflows/release-publish.yml
@@ -1,0 +1,13 @@
+name: Release Publish
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18
+    secrets:
+      token: {{"${{"}} secrets.GITHUB_TOKEN {{"}}"}}


### PR DESCRIPTION
## Summary
- The `branching-model` spec lists four required release-management workflows. The template tree shipped only three: `release-drafter.yml`, `release-cd-refresh-master.yml`, `automerge.yaml`. Every generated project was non-compliant from the first render.
- Add the missing `release-publish.yml` as a thin caller of `reusable-release-publish.yml@v1.1.18`, triggered only by `workflow_dispatch` — the release-automation operational contract is that the publish-trigger skill (or a manual dispatch) is the Draft → Published audit-trail entry point.

## Changes
- `{{cookiecutter.module_slug}}/.github/workflows/release-publish.yml` — new file, 13 lines

## Linked issues
None — surfaced by the cookiecutter-template review and the project-structure-apply audit on the outer repo.

## Testing
- [x] Local `cookiecutter --no-input` render
- [x] Output file present at `.github/workflows/release-publish.yml`
- [x] `${{ secrets.GITHUB_TOKEN }}` expression renders unescaped (Cookiecutter passthrough verified)

## Risk / rollout notes
**Consumer impact**: projects generated after this lands ship with the branching-model-compliant workflow set on first render. Existing generated projects need to add the file manually or pick it up via a lifecycle update.

No breaking changes: `workflow_dispatch`-only trigger means the workflow stays dormant until someone explicitly invokes it; the standard release flow continues to run via release-drafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)