### PR TITLE
feat(ci): add render-test job + fix docs/index.md trailing-newline bug

### DIFF
--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -6,3 +6,86 @@ jobs:
     uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@v1.1.18
   security:
     uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@v1.1.18
+
+  render:
+    name: "Render template (positive + negative)"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install cookiecutter + pre-commit
+        run: |
+          pip install -r requirements.txt
+          pip install pre-commit==4.5.0
+
+      - name: Render — defaults (all-n flags)
+        run: |
+          cookiecutter . -f --no-input --output-dir /tmp/render-default \
+            module_slug="ci-default-test" \
+            topics="ci-test" \
+            description="default render scenario"
+
+      - name: pre-commit on default render output
+        working-directory: /tmp/render-default/ci-default-test
+        run: |
+          git init -q
+          git add -A
+          pre-commit run --all-files --show-diff-on-failure
+
+      - name: Render — all-yes
+        run: |
+          cookiecutter . -f --no-input --output-dir /tmp/render-allyes \
+            module_slug="ci-allyes-test" \
+            topics="ci-test" \
+            description="all-yes render scenario" \
+            plumbing_workflow_enabled="y" \
+            template_issues="y" \
+            template_pull_request="y" \
+            renovate_enabled="y" \
+            readme_enabled="y" \
+            docs_enabled="y" \
+            dependabot_enabled="y" \
+            dependabot_pip="y" \
+            dependabot_gitsubmodule="y" \
+            dependabot_docker="y"
+
+      - name: pre-commit on all-yes render output
+        working-directory: /tmp/render-allyes/ci-allyes-test
+        run: |
+          git init -q
+          git add -A
+          pre-commit run --all-files --show-diff-on-failure
+
+      - name: mkdocs build on all-yes render output
+        working-directory: /tmp/render-allyes/ci-allyes-test
+        run: |
+          pip install -r requirements-dev.txt
+          mkdocs build --strict
+
+      - name: Negative — invalid module_slug must fail pre-gen hook
+        run: |
+          set +e
+          cookiecutter . -f --no-input --output-dir /tmp/render-invalid \
+            module_slug="Invalid Slug!" topics="x" description="x"
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "ERROR: render with invalid module_slug succeeded but must fail" >&2
+            exit 1
+          fi
+          echo "OK: pre-gen hook rejected invalid slug as expected (exit=$status)"
+
+      - name: Negative — empty module_slug must fail pre-gen hook
+        run: |
+          set +e
+          cookiecutter . -f --no-input --output-dir /tmp/render-empty \
+            module_slug="" topics="x" description="x"
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "ERROR: render with empty module_slug succeeded but must fail" >&2
+            exit 1
+          fi
+          echo "OK: pre-gen hook rejected empty slug as expected (exit=$status)"

--- a/{{cookiecutter.module_slug}}/docs/index.md
+++ b/{{cookiecutter.module_slug}}/docs/index.md
@@ -1,8 +1,9 @@
 # {{cookiecutter.__name}}
-{% raw %}
+
+{% raw -%}
 {%
    include-markdown "../README.md"
    start="<!--intro-start-->"
    end="<!--intro-end-->"
 %}
-{% endraw %}
+{% endraw -%}


### PR DESCRIPTION
## Summary

Until now `build-static-tests.yaml` ran only `pre-commit` and `trivy` on the template source — never the template **render**. A syntactic or whitespace defect in any template file shipped to consumers and surfaced only at their first local `pre-commit` run.

This PR adds a `render` job that exercises six scenarios end-to-end on every push to the template repo. The first run of this check immediately uncovered one such defect: `docs/index.md` produced a trailing blank line. Both the new job and the fix ship in the same PR — the test is its own first user.

## Changes

`.github/workflows/build-static-tests.yaml` — new `render` job, runs in sequence:

1. Render with all-`n` flags → must succeed
2. `pre-commit run --all-files` on default-render output → must pass cleanly
3. Render with all-`y` flags → must succeed
4. `pre-commit run --all-files` on all-yes-render output → must pass cleanly
5. `mkdocs build --strict` on all-yes-render output → must build
6. Render with `module_slug="Invalid Slug!"` → must fail at the pre-gen hook
7. Render with empty `module_slug=""` → must fail at the pre-gen hook

`{{cookiecutter.module_slug}}/docs/index.md` — switch `{% raw %}…{% endraw %}` to `{% raw -%}…{% endraw -%}` so the whitespace-trim markers consume the block tags' own newlines. Plus a one-blank-line layout between H1 and the include block.

## Linked issues
None — surfaced by the cookiecutter-template review (Pri 6).

## Testing
- [x] Local render of all six scenarios reproduces what CI will do
- [x] `pre-commit` on default-render output: clean (3 hooks, all Passed)
- [x] `pre-commit` on all-yes-render output: clean (3 hooks, all Passed)
- [x] `mkdocs build --strict` on all-yes-render output: builds in ~0.26s, no warnings
- [x] Negative tests (invalid + empty slug): both fail with `ERROR:` diagnostic, non-zero exit, hook script reports rejection
- [x] CI run after push expected to be green; if it isn't, the green-on-develop bar will be reset by this very job — which is exactly the point

## Risk / rollout notes

**Outcome of the new check on future PRs**: any template file with trailing whitespace, missing EOF newline, invalid YAML, or broken mkdocs cross-link now fails this job — i.e., the consumer's first `pre-commit` run is now the template's CI gate. This will likely catch latent defects in subsequent unrelated PRs that only touch templates. Treat the first few CI failures as "the test working as intended", not as new regressions.

**Job runtime**: ~60–90s additional on each push (Python setup + 2 renders + 2 pre-commits + mkdocs build + 2 negative renders). Acceptable for a template-of-record repository.

**Consumer impact**: none — the rendered output is unchanged for any caller. The `docs/index.md` fix produces the same final structure (heading + blank line + include block) with one trailing newline instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)