### PR TITLE
feat(template): wire vale nolte-styles via Packages, drop dead styles placeholder

### DIFF
--- a/{{cookiecutter.module_slug}}/.vale.ini
+++ b/{{cookiecutter.module_slug}}/.vale.ini
@@ -1,11 +1,9 @@
 StylesPath = ".github/styles"
 MinAlertLevel = suggestion
 
-Packages = Microsoft, RedHat
+Packages = Microsoft, RedHat, https://github.com/nolte/vale-style/releases/download/v0.1.3/nolte-styles.zip
 
 IgnoredScopes = code,tt, em
-
-# Vocab = "Technical"
 
 [*.md]
 BasedOnStyles = Vale, Microsoft


### PR DESCRIPTION
## Summary

The template generated projects with `Packages = Microsoft, RedHat` in `.vale.ini` but no path to the **nolte-styles** vocabulary that the outer repo (and the rest of the portfolio) standardises on. `vale sync` in CI downloaded Microsoft and RedHat, then ran half-configured against any nolte-specific terms.

Two changes plus one tidy:

- Add `https://github.com/nolte/vale-style/releases/download/v0.1.3/nolte-styles.zip` to the Packages list — matches the outer repo since the vale work landed in gh-plumbing
- Drop the `.github/styles/.keep` placeholder — `vale sync` creates the directory on first run, and the template's own `.gitignore` already excludes `.github/styles/*` so the `.keep` wasn't even tracked by consumers anyway
- Tidy a stale `# Vocab = "Technical"` commented line that referenced a vocabulary the template doesn't ship

## Changes

- `{{cookiecutter.module_slug}}/.vale.ini`: Packages-line now includes the nolte-styles release URL; dead Vocab comment dropped
- `{{cookiecutter.module_slug}}/.github/styles/.keep` removed (was never tracked; pure on-disk placeholder for an empty directory)

## Linked issues
None — surfaced by the cookiecutter-template review (Pri 11 + Pri 5.3).

## Testing
- [x] Render of an all-yes consumer project: `.vale.ini` carries the three-package list
- [x] `.github/styles/` directory no longer exists in the rendered output — `vale sync` creates it lazily at CI time
- [x] `pre-commit run --all-files` on the rendered output: green
- [x] CI render-test (from PR #175) exercises this on every push

## Risk / rollout notes

**Consumer impact**: projects generated after this lands ship with the nolte vocabulary applied via `vale sync` in their CI workflow. Existing generated projects keep their previous two-package config until they regenerate or manually add the URL.

**Spelling workflow unchanged**: `reusable-spelling-vale.yaml@v1.1.18` already runs `vale sync` before linting, so the new package URL gets pulled the first time the workflow runs on a generated repo. No upstream gh-plumbing change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)