### PR TITLE
chore(workflows): wire automerge + release-publish to portfolio-app token cascade

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -20,5 +20,8 @@ on:
 jobs:
   automerge:
     uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@v1.1.18
+    with:
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -2,6 +2,16 @@ name: Release Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Draft tag to publish. Must match an existing release-drafter draft."
+        required: true
+        type: string
+      dry_run:
+        description: "Validate only; do not flip draft -> published."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -9,5 +19,10 @@ permissions:
 jobs:
   publish:
     uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18
+    with:
+      tag: ${{ inputs.tag }}
+      dry_run: ${{ inputs.dry_run }}
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Pass the portfolio App credentials through to the two reusable workflows
that benefit from a user-initiated installation token over the bot's
\`GITHUB_TOKEN\`. The repo is already at \`gh-plumbing@v1.1.18\` for every
caller; only the App-token cascade was missing.

## Changes

- \`automerge.yaml\`: add \`app-id: \${{ vars.PORTFOLIO_APP_ID }}\` and
  \`secrets.app-private-key: \${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}\`.
- \`release-publish.yml\`: declare the \`tag\` and \`dry_run\` workflow_dispatch
  inputs that the reusable expects (the file used to dispatch without them,
  which would have errored on the missing required \`tag\`); pass the App
  credentials.

## Linked issues

\`nolte/gh-plumbing#330\` — App-installation-token cascade.

## Testing

CI on this PR exercises the App-token path on the next \`automerge\`
trigger. The reusables guard on \`inputs.app-id != ''\` and fall back to
\`secrets.token\` cleanly when the variable is unset.

## Risk / rollout notes

Pure CI wiring. App credentials are populated on every consumer repo by
the \`terraform/portfolio-app/\` apply in \`nolte/terraform-github-bootstrap\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)