### PR TITLE
chore(portfolio): capture repo-specific tech_stack deltas

### DIFF
--- a/project/portfolio.yml
+++ b/project/portfolio.yml
@@ -19,3 +19,26 @@ capabilities:
     peers:
       - gh-plumbing:reusable-github-actions-workflows
       - gh-plumbing:probot-commons-config
+
+# tech_stack: repo-specific deltas vs the inherited portfolio baseline
+# (portfolio/tech-stack.yml). Schema: spec/portfolio/tech-stack/ §Per-repository block.
+tech_stack:
+  additions:
+    - name: python
+      kind: language
+      group: build-tooling
+      version: "3.14.0"
+      role: Implementation language for the Cookiecutter pre/post-generation hooks and the pytest-cookies harness.
+      status: active
+      lifecycle: build
+      source_of_truth: .tool-versions
+      rationale: >-
+        python here drives the template-generation hooks and tests rather than an application
+        runtime, so it is grouped under build-tooling.
+    - name: cookiecutter
+      kind: framework
+      group: build-tooling
+      role: Project-template engine defining the repository's shape; renders a new project from cookiecutter.json plus hooks.
+      status: active
+      lifecycle: build
+      source_of_truth: cookiecutter.json


### PR DESCRIPTION
## Summary

Add a repo-specific `tech_stack:` block to `project/portfolio.yml` capturing only the
**genuine deltas** vs the inherited portfolio baseline (`claude-shared:portfolio/tech-stack.yml`),
per `spec/portfolio/tech-stack/` §Per-repository tech-stack block and `spec/portfolio/tech-stack-discovery/`.
Inherited global entries (mkdocs, renovate, github-actions, task, vale, pre-commit, markdownlint, …)
are intentionally **not** re-declared.

**Note:** `tech-stack-capture` is normally an interactive per-repo skill whose entries the
maintainer confirms one by one. This block was captured cross-repo from repo signals; the
interactive confirmation step is **replaced by this PR review** — please verify the deltas below.

## Captured deltas

python, cookiecutter (template engine)

## Group-enum note

The closed `group` enum (documentation / quality / automation / build-tooling / plugin-platform)
has no application-runtime bucket. Application language/runtime/framework entries are grouped
under `build-tooling` (closest fit, consistent with the `blog` precedent) and flagged in each
entry's `rationale`; lint/test → `quality`; deploy-targets → `automation`. Regroup as you see fit.

## Changes

- `project/portfolio.yml`: added a top-level `tech_stack.additions:` block (signal-backed deltas only).

## Testing

- `project/portfolio.yml` parses as valid YAML; every entry's `kind`/`group`/`status` is within the closed enums.

## Risk / rollout notes

Low. Additive declarative metadata; no code or runtime impact. Reversible by reverting the manifest edit.

Refs nolte/claude-shared#462
